### PR TITLE
sprint 3.26 vestion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ temp_docker_images/*
 .gitlab-ci.yml
 
 manifest.json
+._.DS_Store
+libs/._.DS_Store
+test/._.DS_Store

--- a/apps/deploy/src/deploy.controller.ts
+++ b/apps/deploy/src/deploy.controller.ts
@@ -26,6 +26,17 @@ export class DeployController {
     return "Deploy service is success, Version: " + version
   }
 
+  @MessagePattern(DeployTopics.GET_DEPLOY_STATUSES)
+  async getDeployStatuses(@RpcPayload() data: any) {
+    this.logger.log(`Get deploy statuses for catalogId: ${data.catalogId}`);
+    try {
+      return await this.deployService.getDeployStatuses(data.catalogId);
+    } catch (error) {
+      this.logger.error(`Error getting deploy statuses: ${error.message}`);
+      return [];
+    }
+  }
+
   private readImageVersion() {
     let version = 'unknown'
     try {

--- a/apps/deploy/src/deploy.service.ts
+++ b/apps/deploy/src/deploy.service.ts
@@ -108,4 +108,20 @@ export class DeployService {
 
     return savedMap?.raw?.length > 0 || savedMap.affected > 0
   }
+
+  // Get deploy statuses for a specific catalog
+  async getDeployStatuses(catalogId: string): Promise<DeployStatusEntity[]> {
+    this.logger.log(`Getting deploy statuses for catalogId: ${catalogId}`);
+    try {
+      const statuses = await this.deployStatusRepo.find({
+        where: { catalogId },
+        relations: ['device']
+      });
+      this.logger.debug(`Found ${statuses.length} deploy statuses for catalogId: ${catalogId}`);
+      return statuses;
+    } catch (error) {
+      this.logger.error(`Error getting deploy statuses for catalogId: ${catalogId}, error: ${error.message}`);
+      throw error;
+    }
+  }
 }

--- a/libs/common/src/microservice-client/topics/topics.enums.ts
+++ b/libs/common/src/microservice-client/topics/topics.enums.ts
@@ -40,7 +40,8 @@ export const DeliveryTopics = {
     PREPARED_DELIVERY_STATUS: `getapp-delivery.prepared-status${region}`,
     GET_CACHE_CONFIG: `getapp-delivery.get-cache-config${region}`,
     SET_CACHE_CONFIG: `getapp-delivery.set-cache-config${region}`,
-    CHECK_HEALTH: `getapp-delivery.check-health${region}`
+    CHECK_HEALTH: `getapp-delivery.check-health${region}`,
+    GET_DELIVERY_STATUSES: `getapp-delivery.get-delivery-statuses${region}`,
 } as const
 
 export const DeliveryTopicsEmit = {
@@ -74,7 +75,8 @@ export const OfferingTopicsEmit = {
     DEVICE_MAP_EVENT: `getapp-offering.device.map-event${region}`,
 }
 export const DeployTopics = {
-    CHECK_HEALTH: `getapp-deploy.check-health${region}`
+    CHECK_HEALTH: `getapp-deploy.check-health${region}`,
+    GET_DEPLOY_STATUSES: `getapp-deploy.get-deploy-statuses${region}`,
 } as const
 
 export const DeployTopicsEmit = {


### PR DESCRIPTION
This pull request adds support for retrieving deploy statuses for a specific catalog in the deploy service. It introduces a new message pattern and topic for fetching deploy statuses, implements the corresponding service method, and updates the shared topics enum to include the new topic.

**Deploy status retrieval support:**

* Added a new `@MessagePattern` handler `getDeployStatuses` to `DeployController` that logs the request, calls the service method, and handles errors gracefully.
* Implemented `getDeployStatuses` method in `DeployService` to query deploy statuses for a given `catalogId`, including related device information, with logging and error handling.

**Microservice topics update:**

* Added `GET_DEPLOY_STATUSES` to `DeployTopics` in `libs/common/src/microservice-client/topics/topics.enums.ts` to define the new message topic for deploy status queries.
* Added `GET_DELIVERY_STATUSES` to `DeliveryTopics` in the same file for delivery status queries (possibly for consistency or future use).